### PR TITLE
Drop Python2 as default version to compile library and improvements on test script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,8 +7,8 @@ if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
 
-set(PYTHON_VERSION 2.7)
-set(BOOST_PYTHONLIB python-py27)
+set(PYTHON_VERSION 3.5)
+set(BOOST_PYTHONLIB python-py35)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -ftemplate-depth=1024")
 file(GLOB sgre_SRC_FILES "wrapper/*.cpp" "src/*.cpp" "libs/tess2/source/*.c")

--- a/README.md
+++ b/README.md
@@ -1,14 +1,8 @@
 # SGRE module for Python
 
-## Compiling (Ubuntu 16.04)
+## Compiling (Ubuntu 18.04)
 
-Assuming the following packages are installed: **python, python-dev, cmake, make, gcc, g++, libboost-dev, libboost-python-dev**. By default the module is configured for Python 2.7.
-To use it with Python 3.x, make sure that these additional packages are installed: **python3, python3-dev**. Also, you need to update the following lines in *CMakeLists.txt*:
-
-```
-set(PYTHON_VERSION 3.5)
-set(BOOST_PYTHONLIB python-py35)
-```
+Assuming the following packages are installed: **python, python-dev, python3-dev, cmake, make, gcc, g++, libboost-dev, libboost-python-dev**. By default the module is configured for Python 3.
 
 Execute the following commands to build the Python module (in the directory of *CMakeLists.txt*):
 
@@ -29,7 +23,7 @@ export PYTHONPATH=$PYTHONPATH:`pwd`/build
 
 ## Testing
 
-Now verify that the module works by executing test script (use `python3` if using Python 3):
+Now verify that the module works by executing test script:
 
 ```
 cd test

--- a/test/test.py
+++ b/test/test.py
@@ -1,14 +1,18 @@
-# Make sure that sgre.so is reachable using PYTHONPATH env variable 
+# Make sure that sgre.so is reachable using PYTHONPATH env variable
 import sgre
 
 # Read configuration as a string
-config = open('config.json', 'rb').read()
+with open('config.json', 'rb') as f:
+    config = f.read()
+
 # Read GeoJSON geometry as a string
-geojson = open('navigation.geojson', 'rb').read()
+with open('navigation.geojson', 'rb') as f:
+    geojson = f.read()
+
 # Define name of the profile (use empty string if profiles are not used)
 profile = ''
 
-# Create RouteFinder object. Note that RouteFinder should be reused 
+# Create RouteFinder object. Note that RouteFinder should be reused
 # as much as possible, as creating a new instance is an expensive operation.
 router = sgre.create_routefinder(geojson, config, profile)
 
@@ -16,8 +20,8 @@ router = sgre.create_routefinder(geojson, config, profile)
 origin = sgre.Point(-5.99632725596723, 37.3932610196257, 0)
 destination = sgre.Point(-5.99673452489332, 37.3932966870052, 12)
 query = sgre.Query(origin, destination)
-query.origin_filter = { 'type': 'hallway' }
-query.destination_filter = { 'type': 'hallway' }
+query.origin_filter = {'type': 'hallway'}
+query.destination_filter = {'type': 'hallway'}
 
 # Find the route
 result = router.find(query)


### PR DESCRIPTION
Hi @mtehver ,

We need to use this library on production environments with Python3 as [Python2 end of life is very near (January 2020)](https://www.python.org/dev/peps/pep-0373/#maintenance-releases) so we are proposing to change default `CMake` file to use Python3. For us is easier to update SGRE library inside our projects if you could merge this little change.

Additionally, we have improved the test script using Python contexts to close files after they are used.

Thanks!